### PR TITLE
feat: create avatar component

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -11,5 +11,8 @@ module.exports = {
   ],
   parserOptions: {
     ecmaVersion: 'latest'
+  },
+  rules: {
+    'vue/multi-word-component-names': 0
   }
 }

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,4 +1,6 @@
 import type { Preview } from '@storybook/vue3'
+//loads in the tailwind styles to Storybook:
+import '../src/main.css' 
 
 const preview: Preview = {
   parameters: {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
+    <link href="./src/main.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard Builder</title>
   </head>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,11 +40,23 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "storybook": "^7.0.7",
-        "tailwindcss": "^3.3.1",
+        "tailwindcss": "^3.3.2",
         "typescript": "~4.8.4",
         "vite": "^4.1.4",
         "vitest": "^0.29.1",
         "vue-tsc": "^1.2.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12156,9 +12168,9 @@
       }
     },
     "node_modules/postcss-import": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -12166,7 +12178,7 @@
         "resolve": "^1.1.7"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
@@ -12192,16 +12204,16 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
       "dev": true,
       "dependencies": {
         "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       },
       "funding": {
         "type": "opencollective",
@@ -12221,12 +12233,12 @@
       }
     },
     "node_modules/postcss-nested": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
-      "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.0.11"
       },
       "engines": {
         "node": ">=12.0"
@@ -12729,18 +12741,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ramda": {
       "version": "0.28.0",
@@ -14069,52 +14069,42 @@
       "dev": true
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
-      "integrity": "sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
+      "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
       "dev": true,
       "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
-        "color-name": "^1.1.4",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.17.2",
-        "lilconfig": "^2.0.6",
+        "jiti": "^1.18.2",
+        "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.0.9",
-        "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.4",
-        "postcss-nested": "6.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
         "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
-        "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1",
-        "sucrase": "^3.29.0"
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
         "tailwindcss": "lib/cli.js"
       },
       "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
+        "node": ">=14.0.0"
       }
-    },
-    "node_modules/tailwindcss/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/tar": {
       "version": "6.1.13",
@@ -15676,12 +15666,12 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yauzl": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^7.0.7",
-    "tailwindcss": "^3.3.1",
+    "tailwindcss": "^3.3.2",
     "typescript": "~4.8.4",
     "vite": "^4.1.4",
     "vitest": "^0.29.1",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-undef
 module.exports = {
   plugins: {
     tailwindcss: {},

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,18 @@
-<script setup lang="ts">
+<script lang="ts">
+import { defineComponent } from 'vue'
+import Avatar from './components/Avatar/Avatar.vue';
 
+export default defineComponent({
+  name: 'App',
+  components: {
+    Avatar
+  }
+})
 </script>
 
 <template>
-    <p class="m-3">HELLO WORLD</p>
-</template>
+    <div>
+      <h1>Avatar Component</h1>
+      <Avatar imageUrl="http://placekitten.com/150/150" altText="Placeholder avatar" />
+    </div>
+  </template>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,7 +12,6 @@ export default defineComponent({
 
 <template>
     <div>
-      <h1>Avatar Component</h1>
       <Avatar imageUrl="http://placekitten.com/150/150" altText="Placeholder avatar" />
     </div>
   </template>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,17 +1,16 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
-import Avatar from './components/Avatar/Avatar.vue';
 
 export default defineComponent({
   name: 'App',
   components: {
-    Avatar
+  
   }
 })
 </script>
 
 <template>
     <div>
-      <Avatar imageUrl="http://placekitten.com/150/150" altText="Placeholder avatar" />
+      
     </div>
   </template>

--- a/frontend/src/components/Avatar/Avatar.stories.ts
+++ b/frontend/src/components/Avatar/Avatar.stories.ts
@@ -7,6 +7,13 @@ export default {
   argTypes: {
     imageUrl: { control: 'text' },
     altText: { control: 'text' }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'This is a simple Avatar component that displays an image and alt text.'
+      }
+    }
   }
 } as Meta;
 

--- a/frontend/src/components/Avatar/Avatar.stories.ts
+++ b/frontend/src/components/Avatar/Avatar.stories.ts
@@ -1,0 +1,32 @@
+import type { Story, Meta } from '@storybook/vue3';
+import Avatar from './Avatar.vue';
+
+export default {
+  title: 'Avatar',
+  component: Avatar,
+  argTypes: {
+    imageUrl: { control: 'text' },
+    altText: { control: 'text' }
+  }
+} as Meta;
+
+interface AvatarProps {
+  imageUrl: string;
+  altText: string;
+}
+
+const Template: Story<AvatarProps> = (args: AvatarProps) => ({
+  components: { Avatar },
+  setup() {
+    return { args };
+  },
+  template: '<Avatar :imageUrl="args.imageUrl" :altText="args.altText" />',
+});
+
+export const Default: Story<AvatarProps> = Template.bind({});
+Default.args = {
+  imageUrl: 'https://placekitten.com/150/150',
+  altText: 'Avatar'
+};
+
+

--- a/frontend/src/components/Avatar/Avatar.stories.ts
+++ b/frontend/src/components/Avatar/Avatar.stories.ts
@@ -6,7 +6,12 @@ export default {
   component: Avatar,
   argTypes: {
     imageUrl: { control: 'text' },
-    altText: { control: 'text' }
+    altText: { control: 'text' },
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'radio' },
+      defaultValue: 'md',
+    },
   },
   parameters: {
     docs: {
@@ -20,6 +25,7 @@ export default {
 interface AvatarProps {
   imageUrl: string;
   altText: string;
+  size?: 'sm' | 'md' | 'lg';
 }
 
 const Template: Story<AvatarProps> = (args: AvatarProps) => ({
@@ -27,13 +33,28 @@ const Template: Story<AvatarProps> = (args: AvatarProps) => ({
   setup() {
     return { args };
   },
-  template: '<Avatar :imageUrl="args.imageUrl" :altText="args.altText" />',
+  template: '<Avatar :imageUrl="args.imageUrl" :altText="args.altText" :size="args.size"/>',
 });
 
 export const Default: Story<AvatarProps> = Template.bind({});
 Default.args = {
-  imageUrl: 'https://placekitten.com/150/150',
-  altText: 'Avatar'
+  imageUrl: 'https://placekitten.com/300/300',
+  altText: 'Avatar',
+  size: 'md'
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  imageUrl: 'https://placekitten.com/300/300',
+  altText: 'Small Avatar',
+  size: 'sm'
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  imageUrl: 'https://placekitten.com/300/300',
+  altText: 'Large Avatar',
+  size: 'lg'
 };
 
 

--- a/frontend/src/components/Avatar/Avatar.vue
+++ b/frontend/src/components/Avatar/Avatar.vue
@@ -1,8 +1,16 @@
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, computed } from 'vue'
+
+//an interface helps us manage the types of the props we use
+interface AvatarProps {
+  imageUrl: string;
+  altText: string;
+  size?: 'sm' | 'md' | 'lg';
+}
 
 export default defineComponent({
   name: 'Avatar',
+  //all props are optional by default unless 'required' is specified
   props: {
     imageUrl: {
       type: String,
@@ -11,13 +19,34 @@ export default defineComponent({
     altText: {
       type: String,
       required: true
+    },
+    size: {
+      type: String as () => AvatarProps['size'],
+      validator: (value: string) => ['sm', 'md', 'lg'].includes(value)
     }
+  },
+  setup(props: AvatarProps) {
+    const sizeClass = computed(() => {
+      switch (props.size) {
+        case 'sm':
+          return 'h-8 w-8';
+        case 'lg':
+          return 'h-24 w-24';
+        default:
+          return 'h-16 w-16';
+      }
+    });
+
+    return {
+      sizeClass
+    };
   }
 })
 </script>
 
 <template>
-  <div class="flex justify-center items-center rounded-full overflow-hidden h-16 w-16 bg-gray-200">
+  <!-- computed class is added to div element -->
+  <div class="flex justify-center items-center rounded-full overflow-hidden bg-gray-200" :class="sizeClass">
     <img :src="imageUrl" :alt="altText" class="w-full h-full object-cover">
   </div>
 </template>

--- a/frontend/src/components/Avatar/Avatar.vue
+++ b/frontend/src/components/Avatar/Avatar.vue
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'Avatar',
+  props: {
+    imageUrl: {
+      type: String,
+      required: true
+    },
+    altText: {
+      type: String,
+      required: true
+    }
+  }
+})
+</script>
+
+<template>
+  <div class="flex justify-center items-center rounded-full overflow-hidden h-16 w-16 bg-gray-200">
+    <img :src="imageUrl" :alt="altText" class="w-full h-full object-cover">
+  </div>
+</template>
+
+

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
+// eslint-disable-next-line no-undef
 module.exports = {
-  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}', './src/**/*.stories.ts'],
   theme: {
     extend: {}
   },


### PR DESCRIPTION
## Summary
* Create an avatar component that takes a picture and returns a cropped and rounded version of the photo.
* The size of the avatar component is fixed.
* To test, run `npm run dev` in project terminal and navigate to local host.

## Notes
* There is currently an h1 heading in the App.vue file to specify that there is an avatar component below. This can be removed.
* The imageUrl and altText props are mandatory for the component to work correctly.

## Screenshots
_Component testing on local host:_
![image](https://user-images.githubusercontent.com/104564844/236701132-a637b124-b30a-48fa-9ea2-0ee822d93322.png)

_Storybook component testing:_
![image](https://user-images.githubusercontent.com/104564844/236701165-46143b5c-75d1-470e-a8d7-51abfe647ab7.png)
